### PR TITLE
Add support for Python 3

### DIFF
--- a/python_hmac_auth/hmac_auth.py
+++ b/python_hmac_auth/hmac_auth.py
@@ -16,67 +16,50 @@ class HmacAuth(AuthBase):
     SIGNATURE_DELIM = '\n'
     VERSION_1 = '1'
 
-    def __init__(self, api_key, secret_key,
-                 api_key_query_param = API_KEY_QUERY_PARAM,
-                 signature_http_header = SIGNATURE_HTTP_HEADER,
-                 timestamp_http_header = TIMESTAMP_HTTP_HEADER,
-                 version_http_header = VERSION_HTTP_HEADER):
+    def __init__(self, api_key, secret_key):
         self.api_key = api_key
         self.secret_key = secret_key
-        self.api_key_query_param = api_key_query_param
-        self.signature_http_header = signature_http_header
-        self.timestamp_http_header = timestamp_http_header
-        self.version_http_header = version_http_header
 
     def __call__(self, request):
         self._encode(request)
         return request
 
     def _encode(self, request):
-        timestamp = self._get_current_timestamp()
+        timestamp = _get_current_timestamp()
         self._add_api_key(request)
-        self._add_timestamp(request, timestamp)
+        _add_timestamp(request, timestamp)
         self._add_signature(request, timestamp)
-        self._add_version(request, HmacAuth.VERSION_1)
-
-    def _get_current_timestamp(self):
-        # Return current UTC time in ISO8601 format
-        return datetime.datetime.now(dateutil.tz.tzutc()).isoformat()
+        _add_version(request, HmacAuth.VERSION_1)
 
     def _add_api_key(self, request):
         # Add the API key as a query parameter
         url = request.url
         scheme, netloc, path, query_string, fragment = urlsplit(url)
         query_params = parse_qs(query_string)
-        query_params[self.api_key_query_param] = self.api_key
+        query_params[HmacAuth.API_KEY_QUERY_PARAM] = self.api_key
         new_query_string = urlencode(query_params, doseq=True)
         new_url = urlunsplit((scheme, netloc, path, new_query_string, fragment))
         request.url = new_url
-
-    def _add_timestamp(self, request, timestamp):
-        request.headers[self.timestamp_http_header] = timestamp
-
-    def _add_version(self, request, version):
-        request.headers[self.version_http_header] = version
 
     def _add_signature(self, request, timestamp):
         method = request.method
         path = request.path_url
         content = request.body
         signature = self._sign(method, timestamp, path, content)
-        request.headers[self.signature_http_header] = signature
+        request.headers[HmacAuth.SIGNATURE_HTTP_HEADER] = signature
 
     def _sign(self, method, timestamp, path, content):
         # Build the message to sign
-        message = bytearray(method) +                       \
-                  bytearray(HmacAuth.SIGNATURE_DELIM) +     \
-                  bytearray(timestamp) +                    \
-                  bytearray(HmacAuth.SIGNATURE_DELIM) +     \
-                  bytearray(path)
+
+        message = bytearray(method, 'utf-8') + \
+                  bytearray(HmacAuth.SIGNATURE_DELIM, 'utf-8') + \
+                  bytearray(timestamp, 'utf-8') + \
+                  bytearray(HmacAuth.SIGNATURE_DELIM, 'utf-8') + \
+                  bytearray(path, 'utf-8')
 
         if content:
-            message += bytearray(HmacAuth.SIGNATURE_DELIM) + bytearray(content)
+            message += bytearray(HmacAuth.SIGNATURE_DELIM, 'utf-8') + bytearray(content, 'utf-8')
 
         # Create the signature
-        digest = hmac.new(self.secret_key, message, sha256).digest()
+        digest = hmac.new(key=bytearray(self.secret_key, 'utf-8'), msg=message, digestmod=sha256).digest()
         return base64.urlsafe_b64encode(digest).strip()

--- a/python_hmac_auth/hmac_auth.py
+++ b/python_hmac_auth/hmac_auth.py
@@ -4,8 +4,25 @@ import dateutil.tz
 import hmac
 from hashlib import sha256
 from requests.auth import AuthBase
-from urlparse import parse_qs, urlsplit, urlunsplit
-from urllib import urlencode
+
+try:
+    from urlparse import parse_qs, urlsplit, urlunsplit
+    from urllib import urlencode
+except:
+    from urllib.parse import parse_qs, urlsplit, urlunsplit, urlencode
+
+
+def _get_current_timestamp():
+    # Return current UTC time in ISO8601 format
+    return datetime.datetime.now(dateutil.tz.tzutc()).isoformat()
+
+
+def _add_timestamp(request, timestamp):
+    request.headers[HmacAuth.TIMESTAMP_HTTP_HEADER] = timestamp
+
+
+def _add_version(request, version):
+    request.headers[HmacAuth.VERSION_HTTP_HEADER] = version
 
 
 class HmacAuth(AuthBase):

--- a/python_hmac_auth/hmac_auth.py
+++ b/python_hmac_auth/hmac_auth.py
@@ -1,14 +1,14 @@
 import base64
 import datetime
-import dateutil.tz
 import hmac
 from hashlib import sha256
+import dateutil.tz
 from requests.auth import AuthBase
 
 try:
     from urlparse import parse_qs, urlsplit, urlunsplit
     from urllib import urlencode
-except:
+except ImportError:
     from urllib.parse import parse_qs, urlsplit, urlunsplit, urlencode
 
 

--- a/python_hmac_auth/hmac_auth.py
+++ b/python_hmac_auth/hmac_auth.py
@@ -17,14 +17,6 @@ def _get_current_timestamp():
     return datetime.datetime.now(dateutil.tz.tzutc()).isoformat()
 
 
-def _add_timestamp(request, timestamp):
-    request.headers[HmacAuth.TIMESTAMP_HTTP_HEADER] = timestamp
-
-
-def _add_version(request, version):
-    request.headers[HmacAuth.VERSION_HTTP_HEADER] = version
-
-
 class HmacAuth(AuthBase):
     API_KEY_QUERY_PARAM = 'apiKey'
     SIGNATURE_HTTP_HEADER = 'X-Auth-Signature'
@@ -44,9 +36,9 @@ class HmacAuth(AuthBase):
     def _encode(self, request):
         timestamp = _get_current_timestamp()
         self._add_api_key(request)
-        _add_timestamp(request, timestamp)
         self._add_signature(request, timestamp)
-        _add_version(request, HmacAuth.VERSION_1)
+        request.headers[HmacAuth.TIMESTAMP_HTTP_HEADER] = timestamp
+        request.headers[HmacAuth.VERSION_HTTP_HEADER] = HmacAuth.VERSION_1
 
     def _add_api_key(self, request):
         # Add the API key as a query parameter

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=['requests']
+    install_requires=['requests', 'python-dateutil']
 )

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,10 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=['requests', 'python-dateutil']

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 from setuptools import setup
 
+
 def read(filename):
-    return open(filename).read()
+    with open(filename, 'r') as f:
+        return f.read()
+
 
 setup(
     name='python-hmac-auth',
-    version='0.4',
+    version='0.5',
     description='Python client for jersey-hmac-auth (https://github.com/bazaarvoice/jersey-hmac-auth)',
     long_description=read('README.md'),
     url='https://github.com/bazaarvoice/python-hmac-auth',
@@ -28,6 +31,6 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        ],
+    ],
     install_requires=['requests']
 )


### PR DESCRIPTION
This PR adds support for Python 3.

- Fix broken `urllib` imports, retaining backwards compatibility for Python 2
- Fix missing encoding arguments
- Fix keys not properly encoded to bytes
- Move static methods out of the `HmacAuth`  class
- Safer readme/version etc. parser
- Refactoring, remove unnecessary attribute assignment from constants
- Add missing `dateutils` dependency to `setup.py`

Closes https://github.com/bazaarvoice/python-hmac-auth/issues/6
Closes https://github.com/bazaarvoice/python-hmac-auth/issues/3